### PR TITLE
Update install to use github wiringpi

### DIFF
--- a/install
+++ b/install
@@ -33,8 +33,8 @@ if [ -e $DEV_FILE ]; then
         sudo apt -y update
         sudo apt -y install build-essential git cmake
         # Installing latest wiringpi compatible with RPI-OS
-        wget https://project-downloads.drogon.net/wiringpi-latest.deb -O /tmp/wiringpi-latest.deb 
-        sudo dpkg -i /tmp/wiringpi-latest.deb
+        wget https://github.com/WiringPi/WiringPi/releases/download/3.4/wiringpi_3.4_arm64.deb -O /tmp/wiringpi-arm64.deb 
+        sudo dpkg -i /tmp/wiringpi-arm64.deb
     fi
 elif [ $expert ]; then
         echo -e 'Expert mode enabled.'


### PR DESCRIPTION
The version of wiringpi included from the old link is showing up as incompatible with the Rasberry Pi zero 2, maybe it's a good idea to make sure this doesn't break the zero 1 before we push this

I believe there was also some libc issue on a clean install prior to me finding this fix but I dont currently have enough time to dig and propose the added install to further improve this PR, happy for discussions on the best way to actual solve the issue I had in #2 