### PR TITLE
Update xenium.service to output to journal

### DIFF
--- a/xenium.service
+++ b/xenium.service
@@ -4,6 +4,9 @@ Description=Advanced Xenium Programmer
 [Service]
 WorkingDirectory=/home/pi/AdvancedXeniumProgrammer
 ExecStart=/home/pi/AdvancedXeniumProgrammer/xeniumListenerAdvanced
+StandardOutput=journal
+StandardError=journal
+Environment="PYTHONUNBUFFERED=x"
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Was having an issue with a headless version of raspbian OS where it was not logging phython3 output

With that said, up until I swapped to a headless version of the OS I was seeing all the logs coming through to my `journalctl -u xenium.service -f` watch, but I started to only get service start/stop logs coming up for some reason.

This change also doesn't resolve the issue that the downstream python scripts it launches (i.e. PromOS-programmer-smd) are also not outputing to the journal.

Would happily close this PR if it turns out I am just bad at linux (very likely) and there is a better way to get my logging working properly